### PR TITLE
docs: fix up typos 🥑

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -95,7 +95,7 @@ export default defineConfig({
 	plugins: [
 		// ... other plugins
 		i18nPlugin({
-			locales: ['en_us', 'en_uk', 'en', 'nl'],
+			locales: ['en_US', 'en_UK', 'en', 'nl'],
 		}),
 	],
 })
@@ -105,7 +105,7 @@ You have to set up your project so the plugin knows the current locale, both on 
 
 ### Server code
 
-**On the server**, you can use the `setLocaleGetter` function to set a callback that returns the current locale, or you can call the `setDefaultLocale` function to set the locale directly if you only process one locale at a time. See [qwik.md](./qwik.md) for an example setup for Qwik.
+**On the server**, you can use the `setLocaleGetter` function to set a callback that returns the current locale, or you can call the `setDefaultLocale` function to set the locale directly if you only process one locale at a time. See [qwik.md](./docs/qwik.md) for an example setup for Qwik.
 
 ### Browser code
 

--- a/docs/qwik.md
+++ b/docs/qwik.md
@@ -249,7 +249,7 @@ import {i18nPlugin} from 'compiled-i18n/vite'
 export default defineConfig({
 	plugins: [
 		i18nPlugin({
-			locales: ['en_us', 'en_uk', 'en', 'nl'],
+			locales: ['en_US', 'en_UK', 'en', 'nl'],
 		}),
 		qwikCity(),
 		qwikVite(),


### PR DESCRIPTION
Fixed docs typos.

<img width="625" height="94" alt="image" src="https://github.com/user-attachments/assets/b7847861-fa38-4aa3-b66f-d0c7611fed4f" />
