### PR TITLE
feat(vite): add usageGlobs to detect key usage in non-transformed files (Astro, etc.)

### DIFF
--- a/docs/astro.md
+++ b/docs/astro.md
@@ -27,6 +27,36 @@ export default defineConfig({
 });
 ```
 
+### Accurate unused/missing key reporting (`usageGlobs`)
+
+compiled-i18n collects used keys from Vite's `transform`, which only runs on
+`.cjs/js/mjs/ts/jsx/tsx`. It never sees `.astro` files, so keys used **only** in
+`.astro` components (especially in template expressions such as
+`<p>{localize\`helloWorld\`}</p>`) are reported as `unused` at build time — and
+would be deleted if you enable `removeUnusedKeys`. (In Astro's multi-pass build
+this can even surface as "every key is unused".)
+
+Pass `usageGlobs` so the plugin also statically scans those files when deciding
+which keys are missing/unused:
+
+```javascript
+vite: {
+  plugins: [
+    i18nPlugin({
+      defaultLocale,
+      locales,
+      usageGlobs: ["src/**/*.astro"],
+    }),
+  ],
+},
+```
+
+This is an opt-in, framework-agnostic option (use it for Vue/Svelte/MDX too).
+It only affects the missing/unused report (and `removeUnusedKeys`), not the
+emitted bundles. The scan is a loose textual match for `_` / `localize`
+tagged-templates, so a match inside a comment counts as "used" — the safe
+direction (it never removes a key that is actually referenced).
+
 ## 2. Dynamic Routes
 
 Astro [Dynamic Routes](https://docs.astro.build/en/guides/routing/#dynamic-routes) can be used to create single pages that resolve differently based on the current locale. For example a `pages/[locale]/index.astro` file can resolve to `pages/en/index.astro` & `pages/fr/index.astro`.

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
   },
   "dependencies": {
     "@babel/core": "^7.27.4",
-    "@babel/plugin-syntax-typescript": "^7.27.1"
+    "@babel/plugin-syntax-typescript": "^7.27.1",
+    "tinyglobby": "^0.2.16"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@babel/plugin-syntax-typescript':
         specifier: ^7.27.1
         version: 7.27.1(@babel/core@7.27.4)
+      tinyglobby:
+        specifier: ^0.2.16
+        version: 0.2.16
     devDependencies:
       '@builder.io/qwik':
         specifier: ^1.14.1
@@ -1044,6 +1047,15 @@ packages:
       picomatch:
         optional: true
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -1477,6 +1489,10 @@ packages:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   postcss@8.5.4:
     resolution: {integrity: sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1653,8 +1669,8 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyglobby@0.2.14:
-    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tinypool@1.1.0:
@@ -2857,6 +2873,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
@@ -3338,6 +3358,8 @@ snapshots:
 
   picomatch@4.0.2: {}
 
+  picomatch@4.0.4: {}
+
   postcss@8.5.4:
     dependencies:
       nanoid: 3.3.11
@@ -3505,10 +3527,10 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
-  tinyglobby@0.2.14:
+  tinyglobby@0.2.16:
     dependencies:
-      fdir: 6.4.5(picomatch@4.0.2)
-      picomatch: 4.0.2
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinypool@1.1.0: {}
 
@@ -3599,7 +3621,7 @@ snapshots:
       picomatch: 4.0.2
       postcss: 8.5.4
       rollup: 4.42.0
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.16
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -3622,7 +3644,7 @@ snapshots:
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.16
       tinypool: 1.1.0
       tinyrainbow: 2.0.0
       vite: 6.3.5

--- a/src/fixture/astro-entry.ts
+++ b/src/fixture/astro-entry.ts
@@ -1,0 +1,2 @@
+// Entry with no i18n usage: keys must come purely from the usageGlobs scan.
+export const x = 1

--- a/src/fixture/i18n-astro/te_ST.json
+++ b/src/fixture/i18n-astro/te_ST.json
@@ -1,0 +1,11 @@
+{
+  "locale": "te_ST",
+  "name": "Test",
+  "translations": {
+    "astro_only_key": "AOK",
+    "astro_attr_key": "AAK",
+    "astro_count $1": "ACK",
+    "genuinely_unused": "GONE",
+    "astro_call_key": "ACALL"
+  }
+}

--- a/src/fixture/uses-in-astro.astro
+++ b/src/fixture/uses-in-astro.astro
@@ -1,0 +1,7 @@
+---
+import {_} from 'compiled-i18n'
+const n = 3
+---
+<p>{_`astro_only_key`}</p>
+<span title={_`astro_attr_key`}>{_`astro_count ${n}`}</span>
+<b>{_("astro_call_key")}</b>

--- a/src/scan-usage.test.ts
+++ b/src/scan-usage.test.ts
@@ -1,5 +1,5 @@
 import {test, expect} from 'vitest'
-import path from 'path'
+import {fileURLToPath} from 'node:url'
 import {extractKeys, scanUsageKeys} from './scan-usage'
 
 const names = new Set(['_', 'localize'])
@@ -34,6 +34,11 @@ test('handles nested template in expression', () => {
 	expect(extractKeys('_`a ${cond ? `x` : `y`} b`', names)).toEqual(['a $1 b'])
 })
 
+test('braces inside strings/comments in interpolation stay balanced', () => {
+	expect(extractKeys("_`a ${f('}')} b`", names)).toEqual(['a $1 b'])
+	expect(extractKeys('_`a ${/* } */ x} b`', names)).toEqual(['a $1 b'])
+})
+
 test('extracts call form _("key") / _(\'key\')', () => {
 	expect(extractKeys('_("call_key")', names)).toEqual(['call_key'])
 	expect(extractKeys("localize('call_key2')", names)).toEqual(['call_key2'])
@@ -44,13 +49,18 @@ test('extracts call form with template arg', () => {
 	expect(extractKeys('_(`tpl ${x}`)', names)).toEqual(['tpl $1'])
 })
 
+test('decodes common string escapes via lookup', () => {
+	expect(extractKeys("_('a\\vb')", names)).toEqual(['a\vb'])
+	expect(extractKeys("_('a\\0b')", names)).toEqual(['a\0b'])
+})
+
 test('call form ignores non-static first arg', () => {
 	expect(extractKeys('_(dynamicVar)', names)).toEqual([])
 	expect(extractKeys('_(cond ? "a" : "b")', names)).toEqual([])
 })
 
 test('scanUsageKeys reads .astro fixture from disk', () => {
-	const root = path.resolve(import.meta.url.slice(5), '../fixture')
+	const root = fileURLToPath(new URL('./fixture', import.meta.url))
 	const keys = scanUsageKeys(['uses-in-astro.astro'], root)
 	expect(keys.has('astro_only_key')).toBe(true)
 	expect(keys.has('astro_attr_key')).toBe(true)

--- a/src/scan-usage.test.ts
+++ b/src/scan-usage.test.ts
@@ -1,0 +1,59 @@
+import {test, expect} from 'vitest'
+import path from 'path'
+import {extractKeys, scanUsageKeys} from './scan-usage'
+
+const names = new Set(['_', 'localize'])
+
+test('extracts static keys', () => {
+	expect(extractKeys('_`hello`', names)).toEqual(['hello'])
+	expect(extractKeys('localize`a_b_c`', names)).toEqual(['a_b_c'])
+})
+
+test('extracts interpolated keys with $N placeholders', () => {
+	expect(extractKeys('_`title ${x}`', names)).toEqual(['title $1'])
+	expect(extractKeys('_`${a} and ${b}!`', names)).toEqual(['$1 and $2!'])
+})
+
+test('escapes literal $ like makeKey', () => {
+	expect(extractKeys('_`5$ off`', names)).toEqual(['5$$ off'])
+})
+
+test('ignores member access and lookalikes', () => {
+	expect(extractKeys('obj._`x`', names)).toEqual([])
+	expect(extractKeys('not_`x`', names)).toEqual([])
+	expect(extractKeys('`plain template`', names)).toEqual([])
+})
+
+test('respects aliased import names', () => {
+	const code = `import {localize as t} from 'compiled-i18n'\nconst s = t\`aliased_key\``
+	// Caller passes the resolved names; here simulate the alias resolution.
+	expect(extractKeys(code, new Set(['t']))).toContain('aliased_key')
+})
+
+test('handles nested template in expression', () => {
+	expect(extractKeys('_`a ${cond ? `x` : `y`} b`', names)).toEqual(['a $1 b'])
+})
+
+test('extracts call form _("key") / _(\'key\')', () => {
+	expect(extractKeys('_("call_key")', names)).toEqual(['call_key'])
+	expect(extractKeys("localize('call_key2')", names)).toEqual(['call_key2'])
+	expect(extractKeys('_( "spaced" )', names)).toEqual(['spaced'])
+})
+
+test('extracts call form with template arg', () => {
+	expect(extractKeys('_(`tpl ${x}`)', names)).toEqual(['tpl $1'])
+})
+
+test('call form ignores non-static first arg', () => {
+	expect(extractKeys('_(dynamicVar)', names)).toEqual([])
+	expect(extractKeys('_(cond ? "a" : "b")', names)).toEqual([])
+})
+
+test('scanUsageKeys reads .astro fixture from disk', () => {
+	const root = path.resolve(import.meta.url.slice(5), '../fixture')
+	const keys = scanUsageKeys(['uses-in-astro.astro'], root)
+	expect(keys.has('astro_only_key')).toBe(true)
+	expect(keys.has('astro_attr_key')).toBe(true)
+	expect(keys.has('astro_count $1')).toBe(true)
+	expect(keys.has('astro_call_key')).toBe(true)
+})

--- a/src/scan-usage.ts
+++ b/src/scan-usage.ts
@@ -58,7 +58,9 @@ const readTemplate = (
 			quasis.push(cur)
 			cur = ''
 			i += 2
-			// Skip the balanced expression, tolerating nested braces and templates.
+			// Skip the balanced expression. Strings, nested templates and
+			// comments are skipped whole so a `{`/`}` inside them can't
+			// unbalance the brace counter (regex literals are best-effort).
 			let depth = 1
 			while (i < len && depth > 0) {
 				const d = code[i]
@@ -74,6 +76,20 @@ const readTemplate = (
 					if (!nested) return null
 					i = nested.end
 					continue
+				} else if (d === '"' || d === "'") {
+					const str = readStringLiteral(code, i)
+					if (!str) return null
+					i = str.end
+					continue
+				} else if (d === '/' && code[i + 1] === '/') {
+					i += 2
+					while (i < len && code[i] !== '\n') i++
+					continue
+				} else if (d === '/' && code[i + 1] === '*') {
+					i += 2
+					while (i < len && !(code[i] === '*' && code[i + 1] === '/')) i++
+					i += 2
+					continue
 				}
 				i++
 			}
@@ -83,6 +99,18 @@ const readTemplate = (
 		i++
 	}
 	return null
+}
+
+// Single-character escapes we resolve when reading string keys. Anything else
+// (including \\, \', \", \`) falls through to itself.
+const stringEscapes: Record<string, string> = {
+	n: '\n',
+	t: '\t',
+	r: '\r',
+	b: '\b',
+	f: '\f',
+	v: '\v',
+	'0': '\0',
 }
 
 /**
@@ -102,8 +130,8 @@ const readStringLiteral = (
 		const c = code[i]
 		if (c === '\\') {
 			const next = code[i + 1]
-			// Keys are plain text; resolve the few escapes that could appear.
-			value += next === 'n' ? '\n' : next === 't' ? '\t' : (next ?? '')
+			// Keys are plain text; resolve the common escapes, pass others through.
+			value += next === undefined ? '' : (stringEscapes[next] ?? next)
 			i += 2
 			continue
 		}

--- a/src/scan-usage.ts
+++ b/src/scan-usage.ts
@@ -1,0 +1,194 @@
+import fs from 'node:fs'
+import {globSync} from 'tinyglobby'
+import {makeKey} from './makeKey'
+import type {Key} from 'compiled-i18n'
+
+/**
+ * Find the local names that `_` / `localize` are imported as from
+ * `compiled-i18n`, e.g. `import {_, localize as t} from 'compiled-i18n'` yields
+ * `["_", "t"]`.
+ */
+const findLocalizeNames = (code: string): Set<string> => {
+	const names = new Set<string>()
+	const importRe =
+		/import\s*(?:type\s+)?\{([^}]*)\}\s*from\s*['"]compiled-i18n['"]/g
+	let m: RegExpExecArray | null
+	while ((m = importRe.exec(code))) {
+		for (const raw of m[1].split(',')) {
+			const seg = raw.trim()
+			if (!seg) continue
+			const asMatch = /^(\w+)\s+as\s+(\w+)$/.exec(seg)
+			if (asMatch) {
+				if (asMatch[1] === '_' || asMatch[1] === 'localize')
+					names.add(asMatch[2])
+			} else if (seg === '_' || seg === 'localize') {
+				names.add(seg)
+			}
+		}
+	}
+	return names
+}
+
+/**
+ * Read a template literal starting at `code[start] === '\`'`, returning the
+ * static quasi parts (with `${…}` expressions removed) and the index just past
+ * the closing backtick. Returns null if the template is unterminated.
+ */
+const readTemplate = (
+	code: string,
+	start: number
+): {quasis: string[]; end: number} | null => {
+	const len = code.length
+	let i = start + 1
+	let cur = ''
+	const quasis: string[] = []
+	while (i < len) {
+		const c = code[i]
+		if (c === '\\') {
+			// Keep escaped char verbatim; keys rarely contain escapes.
+			cur += c + (code[i + 1] ?? '')
+			i += 2
+			continue
+		}
+		if (c === '`') {
+			quasis.push(cur)
+			return {quasis, end: i + 1}
+		}
+		if (c === '$' && code[i + 1] === '{') {
+			quasis.push(cur)
+			cur = ''
+			i += 2
+			// Skip the balanced expression, tolerating nested braces and templates.
+			let depth = 1
+			while (i < len && depth > 0) {
+				const d = code[i]
+				if (d === '{') depth++
+				else if (d === '}') {
+					depth--
+					if (depth === 0) {
+						i++
+						break
+					}
+				} else if (d === '`') {
+					const nested = readTemplate(code, i)
+					if (!nested) return null
+					i = nested.end
+					continue
+				}
+				i++
+			}
+			continue
+		}
+		cur += c
+		i++
+	}
+	return null
+}
+
+/**
+ * Read a single- or double-quoted string literal starting at the quote at
+ * `code[start]`, returning its (minimally unescaped) value and the index just
+ * past the closing quote, or null if unterminated.
+ */
+const readStringLiteral = (
+	code: string,
+	start: number
+): {value: string; end: number} | null => {
+	const quote = code[start]
+	const len = code.length
+	let i = start + 1
+	let value = ''
+	while (i < len) {
+		const c = code[i]
+		if (c === '\\') {
+			const next = code[i + 1]
+			// Keys are plain text; resolve the few escapes that could appear.
+			value += next === 'n' ? '\n' : next === 't' ? '\t' : (next ?? '')
+			i += 2
+			continue
+		}
+		if (c === quote) return {value, end: i + 1}
+		value += c
+		i++
+	}
+	return null
+}
+
+const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+/**
+ * Extract translation keys from `code` for the given localize tag names.
+ *
+ * Recognizes both call forms compiled-i18n supports:
+ *
+ * - Tagged template: `_`some key ${x}`` → `makeKey` (with `$N` placeholders)
+ * - Function call with a static string/template arg: `_("some key")`
+ *
+ * This is a deliberately loose textual scan (no full JS/HTML parse) so it can
+ * read keys out of files the bundler transform never sees — most importantly
+ * Astro/Vue/Svelte components, where usage lives in template expressions. A
+ * match inside a comment or string would count as "used"; that is the safe
+ * direction (it never causes a used key to be deleted/reported unused).
+ */
+export const extractKeys = (code: string, names: Set<string>): Key[] => {
+	if (!names.size) return []
+	const keys: Key[] = []
+	const len = code.length
+	// Match any localize name as a standalone identifier (not `obj._`, not
+	// `foo_`), followed by optional whitespace.
+	const nameAlt = [...names].map(escapeRegExp).join('|')
+	const re = new RegExp(`(?<![\\w$.])(?:${nameAlt})[ \\t]*`, 'g')
+	let m: RegExpExecArray | null
+	const pushTemplate = (at: number): number | null => {
+		const parsed = readTemplate(code, at)
+		if (!parsed) return null
+		const key = makeKey(parsed.quasis)
+		if (!/[\r\n]/.test(key)) keys.push(key)
+		return parsed.end
+	}
+	while ((m = re.exec(code))) {
+		const pos = m.index + m[0].length
+		const ch = code[pos]
+		if (ch === '`') {
+			const end = pushTemplate(pos)
+			if (end != null) re.lastIndex = end
+		} else if (ch === '(') {
+			let p = pos + 1
+			while (p < len && (code[p] === ' ' || code[p] === '\t')) p++
+			const q = code[p]
+			if (q === '"' || q === "'") {
+				const str = readStringLiteral(code, p)
+				if (str && !/[\r\n]/.test(str.value)) {
+					keys.push(str.value)
+					re.lastIndex = str.end
+				}
+			} else if (q === '`') {
+				const end = pushTemplate(p)
+				if (end != null) re.lastIndex = end
+			}
+		}
+	}
+	return keys
+}
+
+/**
+ * Scan the files matched by `globs` (relative to `root`) for translation-key
+ * usages and return the set of keys found. Files that don't import
+ * `compiled-i18n` are skipped cheaply.
+ */
+export const scanUsageKeys = (globs: string[], root: string): Set<Key> => {
+	const used = new Set<Key>()
+	const files = globSync(globs, {cwd: root, absolute: true})
+	for (const file of files) {
+		let code: string
+		try {
+			code = fs.readFileSync(file, 'utf8')
+		} catch {
+			continue
+		}
+		if (!code.includes('compiled-i18n')) continue
+		const names = findLocalizeNames(code)
+		for (const key of extractKeys(code, names)) used.add(key)
+	}
+	return used
+}

--- a/src/vite.test.ts
+++ b/src/vite.test.ts
@@ -1,4 +1,4 @@
-import {test, expect} from 'vitest'
+import {test, expect, vi} from 'vitest'
 import {Rollup, build} from 'vite'
 import {i18nPlugin} from './vite'
 import path from 'path'
@@ -225,4 +225,55 @@ test('store', async () => {
 		"const t={te_ST:{translations:{}}};let a="te_ST";const s=(o,n=a)=>{if(!t[n])throw new Error(\`loadTranslations: Invalid locale \${n}\`);Object.assign(t[a].translations,o)};s({hi:"hello"},"te_ST");
 		"
 	`)
+})
+
+// Build with an entry that uses no translations, so the only keys that can be
+// "used" are the ones discovered by scanning usageGlobs (the .astro fixture).
+const buildWithUsageGlobs = async (usageGlobs?: string[]) => {
+	const infos: string[] = []
+	const spy = vi
+		.spyOn(console, 'info')
+		.mockImplementation((...args) => void infos.push(args.join(' ')))
+	try {
+		await build({
+			root,
+			plugins: [
+				i18nPlugin({
+					locales: ['te_ST'],
+					localesDir: 'i18n-astro',
+					addMissing: false,
+					...(usageGlobs ? {usageGlobs} : {}),
+				}),
+			],
+			resolve: {alias: {'compiled-i18n': path.resolve(root, '..')}},
+			mode: 'production',
+			logLevel: 'silent',
+			build: {
+				ssr: false,
+				rollupOptions: {
+					input: path.resolve(root, 'astro-entry.ts'),
+					output: {entryFileNames: '[name].js'},
+				},
+				write: false,
+			},
+		})
+	} finally {
+		spy.mockRestore()
+	}
+	return infos.find(s => s.includes('i18n te_ST')) || ''
+}
+
+test('usageGlobs: keys used only in .astro are counted, genuinely unused reported', async () => {
+	const msg = await buildWithUsageGlobs(['uses-in-astro.astro'])
+	expect(msg).toContain('unused 1')
+	expect(msg).toContain('genuinely_unused')
+	expect(msg).not.toContain('astro_only_key')
+	expect(msg).not.toContain('astro_attr_key')
+	expect(msg).not.toContain('astro_count')
+})
+
+test('without usageGlobs, .astro-only keys are falsely reported unused (baseline)', async () => {
+	const msg = await buildWithUsageGlobs(undefined)
+	expect(msg).toContain('unused 5')
+	expect(msg).toContain('astro_only_key')
 })

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -3,6 +3,7 @@ import type {UserConfig, Plugin} from 'vite'
 import fs from 'node:fs'
 import type {Locale, Data, Key} from 'compiled-i18n'
 import {replaceGlobals, transformLocalize} from './transform-localize'
+import {scanUsageKeys} from './scan-usage'
 
 type Options = {
 	/** The locales you want to support */
@@ -27,6 +28,23 @@ type Options = {
 	removeUnusedKeys?: boolean
 	/** Use tabs on new JSON files */
 	tabs?: boolean
+	/**
+	 * Glob patterns (relative to the Vite root) of extra source files to scan for
+	 * `_` / `localize` tagged-template usage when deciding which keys are
+	 * missing/unused.
+	 *
+	 * The bundler `transform` only sees `.cjs/js/mjs/ts/jsx/tsx`, so keys used
+	 * only in files of other types — e.g. Astro/Vue/Svelte components, where
+	 * usage often lives in template expressions — would otherwise be reported as
+	 * unused (and removed by `removeUnusedKeys`). This opt-in static scan reads
+	 * those files directly so the missing/unused report is accurate regardless of
+	 * which build pass ran.
+	 *
+	 * The scan is a loose textual match (see ./scan-usage): a match in a comment
+	 * or string counts as "used" — the safe direction. Example: `usageGlobs:
+	 * ['src/**\/*.astro']`.
+	 */
+	usageGlobs?: string[]
 }
 
 // const c = (...args: any[]): any => {
@@ -48,6 +66,7 @@ export function i18nPlugin(options: Options = {}): Plugin[] {
 		addMissing = true,
 		removeUnusedKeys = false,
 		tabs,
+		usageGlobs,
 	} = options
 	let assetsDir = options.assetsDir
 	if (assetsDir && !assetsDir.endsWith('/')) assetsDir += '/'
@@ -56,6 +75,11 @@ export function i18nPlugin(options: Options = {}): Plugin[] {
 	const localeNames = {}
 	let localesDirAbs: string
 	let localesDirNode: string
+	let root = ''
+	// Cached result of scanning `usageGlobs`. Computed lazily once and reused
+	// across Vite's multiple build passes (it is filesystem-based, so it does
+	// not depend on which pass is running).
+	let scannedKeys: Set<Key> | undefined
 
 	let shouldInline = false
 	let translations: Record<Locale, Data>
@@ -83,6 +107,7 @@ export function i18nPlugin(options: Options = {}): Plugin[] {
 
 			configResolved(config) {
 				// c(config)
+				root = config.root
 				localesDirAbs = resolve(config.root, localesDir)
 				localesDirNode =
 					sep !== '/' ? localesDirAbs.replaceAll(sep, '/') : localesDirAbs
@@ -295,12 +320,24 @@ export const setLocaleGetter = fn => {
 
 			buildEnd() {
 				if (!shouldInline) return
+				// Keys considered "used": those collected by the bundler transform
+				// plus those found by scanning `usageGlobs` (e.g. .astro files).
+				let usedKeys = allKeys
+				if (usageGlobs?.length) {
+					if (!scannedKeys) scannedKeys = scanUsageKeys(usageGlobs, root)
+					usedKeys = new Set(allKeys)
+					for (const key of scannedKeys) usedKeys.add(key)
+					// An empty set here means this pass saw no usage at all (e.g. a
+					// transform-less build pass and a glob that matched nothing) — do
+					// not treat every key as unused, that would wrongly delete them.
+					if (!usedKeys.size) return
+				}
 				for (const locale of locales!) {
-					const missingKeys = new Set(allKeys)
+					const missingKeys = new Set(usedKeys)
 					const unusedKeys = new Set<Key>()
 					for (const key of Object.keys(translations[locale].translations)) {
 						missingKeys.delete(key)
-						if (!allKeys.has(key)) unusedKeys.add(key)
+						if (!usedKeys.has(key)) unusedKeys.add(key)
 					}
 
 					if (missingKeys.size || unusedKeys.size)


### PR DESCRIPTION
## Problem

Used-key collection is tied to the Vite `transform` hook, whose filter only matches `.cjs/js/mjs/ts/jsx/tsx`. Files of other types are never scanned, so keys used **only** in e.g. **Astro/Vue/Svelte components** — where usage often lives in *template expressions* like:

```astro
<p>{localize`helloWorld`}</p>
```

— are reported as `unused`, and would be deleted by `removeUnusedKeys`.

It's worse under Astro's `output: 'server'` builds, which run the plugin over multiple passes: one pass runs `buildEnd` with an **empty** `allKeys` set, so it reports *every* key as unused.

Extending the `transform` regex to `.astro` doesn't work: raw `.astro` isn't JS-parsable, the i18n transform runs before Astro compiles the file, and `transform` is gated on `shouldInline` (client + production only), so SSR usage is never seen.

## Solution — opt-in `usageGlobs`

A new option that statically scans the matched source files for `_` / `localize` usage and unions the found keys into the set used for missing/unused reporting (and `removeUnusedKeys`):

```js
i18nPlugin({ locales, usageGlobs: ['src/**/*.astro'] })
```

Design notes (why this should be safe to merge):

- **Opt-in & backward-compatible** — defaults to off; existing users see zero change.
- **General, not Astro-specific** — it fixes the root limitation (usage detection is bound to the JS bundler transform) for *any* file type the transform doesn't process (Astro/Vue/Svelte/MDX). It's framework-agnostic config, not special-casing.
- **Separation of concerns** — it only affects the missing/unused *report* and `removeUnusedKeys`; it never touches the inlining / emitted bundles. It reuses the library's own `makeKey`, so scanned keys are identical to transform-collected ones.
- **Also fixes the "every key unused" empty-pass artifact**, because the report no longer depends on which build pass ran.
- **Honest tradeoff** — the extractor is a deliberately *loose* textual scan (no full AST/compiler parse, to avoid a heavy framework dependency). It over-counts in the safe direction: a match inside a comment counts as "used", so a referenced key is never wrongly deleted/reported. If you'd prefer maximum precision, this could later grow a pluggable `extract(code, id)` hook — happy to follow up.

The scanner recognizes both supported call forms:

```ts
// tagged template
_`some key ${x}`
// function call (static string or template arg)
_("some key")
_(`some key`)
```

## Changes

- `src/scan-usage.ts` — the scanner (`findLocalizeNames`, `extractKeys`, `scanUsageKeys`); reuses `makeKey`.
- `src/vite.ts` — `usageGlobs` option, lazy-cached scan, wired into `buildEnd` (missing/unused + `removeUnusedKeys`) with an empty-set guard.
- Adds `tinyglobby` for glob expansion.
- Tests: `src/scan-usage.test.ts` (unit) + two cases in `src/vite.test.ts` (an `.astro` fixture's keys are counted; without `usageGlobs` they are falsely reported unused).
- `docs/astro.md` — documents the option and the loose-scan caveat.

`pnpm test` (52 tests) and `pnpm build` pass.

## Real-world validation

In a production Astro SSR app (~155 keys, ~120 `.astro` usages), the `unused`-keys report went from flagging **all ~155 keys** (false positives) to **5** — which were the only genuinely-dead keys (verified by hand). No runtime or bundle change.
